### PR TITLE
Added a disabled dates list

### DIFF
--- a/build/components/Datepicker/Calendar.js
+++ b/build/components/Datepicker/Calendar.js
@@ -147,6 +147,7 @@ function (_Component) {
         displayDate: this.state.displayDate,
         key: this.state.displayDate.toDateString(),
         selectedDates: this.props.selectedDates,
+        disabledDates: this.props.disabledDates,
         minDate: this.getMinDate(),
         maxDate: this.getMaxDate(),
         onSelect: this.props.onSelect,

--- a/build/components/Datepicker/Month.js
+++ b/build/components/Datepicker/Month.js
@@ -61,6 +61,7 @@ function (_Component) {
           selected: _this.props.selected,
           selectedDates: _this.props.selectedDates,
           onSelect: _this.props.onSelect,
+          disabledDates: _this.props.disabledDates,
           minDate: _this.props.minDate,
           maxDate: _this.props.maxDate
         });

--- a/build/components/Datepicker/Week.js
+++ b/build/components/Datepicker/Week.js
@@ -85,8 +85,9 @@ function (_Component) {
       if (!_this.isDisabled(day)) _this.props.onSelect(day);
     }, _this.isDisabled = function (day) {
       var minDate = _this.props.minDate,
-          maxDate = _this.props.maxDate;
-      return minDate && _utils.default.isBefore(day, minDate) || maxDate && _utils.default.isAfter(day, maxDate);
+          maxDate = _this.props.maxDate,
+          disabledDates = _this.props.disabledDates;
+      return minDate && _utils.default.isBefore(day, minDate) || maxDate && _utils.default.isAfter(day, maxDate) || disabledDates && _utils.default.dateIn(disabledDates, day);
     }, _this.isSelected = function (day) {
       return _this.props.selectedDates && _utils.default.dateIn(_this.props.selectedDates, day);
     }, _temp));

--- a/build/components/Datepicker/index.js
+++ b/build/components/Datepicker/index.js
@@ -66,6 +66,7 @@ function (_Component) {
 
     _this.onSelect = function (day) {
       var selectedDates = _this.state.selectedDates;
+      var disabledDates = _this.props.disabledDates || [];
 
       if (_utils.default.dateIn(selectedDates, day)) {
         _this.setState({
@@ -73,7 +74,7 @@ function (_Component) {
             return !_utils.default.isSameDay(date, day);
           })
         });
-      } else {
+      } else if (!_utils.default.dateIn(disabledDates, day)) {
         _this.setState({
           selectedDates: [].concat(_toConsumableArray(selectedDates), [day])
         });
@@ -157,6 +158,7 @@ function (_Component) {
         selected: this.state.selected,
         selectedDates: this.state.selectedDates,
         onSelect: this.onSelect,
+        disabledDates: this.props.disabledDates,
         minDate: this.props.minDate,
         maxDate: this.props.maxDate,
         onCancel: this.handleCancel,


### PR DESCRIPTION
I have added an new optional prop to the MultipleDatePicker component called disabledDates. the new prop expects a list of dates and it disable them from the calendar so the user won't be able to pick them. 

This is useful in cases like mine where you want the user not being able to pick some dates (In my case I don't want them to pick neither weekends nor holidays) so I have a list with all the weekends and holidays dates on it.